### PR TITLE
Binning float fix 

### DIFF
--- a/RPFandToyGen.py
+++ b/RPFandToyGen.py
@@ -1,0 +1,77 @@
+from TwoDAlphabet.twoDalphabet import MakeCard, TwoDAlphabet
+from TwoDAlphabet.alphawrap import BinnedDistribution, ParametricFunction, SemiParametricFunction
+import ROOT
+from argparse import ArgumentParser
+
+def _generate_constraints(nparams):
+    out = {}
+    for i in range(nparams):
+        if i == 0:
+            out[i] = {"MIN":-500,"MAX":500}
+        else:
+            out[i] = {"MIN":-500,"MAX":500}
+    return out
+
+_rpf_options = {
+    '0x0': {
+        'form': '(@0)',
+        'constraints': _generate_constraints(1)
+    },
+    '1x0': {
+        'form': '(@0+@1*x)',
+        'constraints': _generate_constraints(2)
+    },
+    '0x1': {
+        'form': '(@0+@1*y)',
+        'constraints': _generate_constraints(2)
+    },
+    '1x1': {
+        'form': '(@0+@1*x)*(@2+@3*y)',
+        'constraints': _generate_constraints(3)
+    },
+    '2x1': {
+        'form': '(@0+@1*x+@2*x**2)*(@3+@4*y)',
+        'constraints': _generate_constraints(4)
+    },
+    '2x2': {
+        'form': '(@0+@1*x+@2*x**2)*(@3+@4*y*@5*y**2)',
+        'constraints': _generate_constraints(4)
+    },
+    '3x2': {
+        'form': '(@0+@1*x+@2*x**2+@3*x**3)*(@4+@5*y)',
+        'constraints': _generate_constraints(4)
+    }
+}
+
+parser = ArgumentParser()
+parser.add_argument('-w', type=str, dest='workspace',
+                    action='store', required=True,
+                    help='Setname to process.')
+parser.add_argument('-f', type=str, dest='func',
+                    action='store', required=True,
+                    help='transfer function used. e.g. "b_2x1"')
+args = parser.parse_args()
+
+workspace = args.workspace
+
+# Load up a previous workspace with fits already performed
+twoD = TwoDAlphabet(workspace,'{}/runConfig.json'.format(workspace),findreplace={},loadPrevious=True)
+
+# The new function saves the transfer function shapes (in the original input binning) to a
+# new ROOT file, and returns the histograms themselves for use.
+rpf_dict = twoD.GetTransferFunctionShapes(binName='default',rpfOpts=_rpf_options)
+
+# Now we produce a pseudo-data toy in the SR.
+# First, declare which regions we want to create a toy for. 
+regions = ['SR_loose','SR_pass'] 
+# Note that these regions may not be included in the TwoDAlphabet's configuration JSON, 
+# but do exist in the input datasets as histograms. As such, we need to do a quick find-and-replace
+findreplace = {'CR_loose':'SR_loose', 'CR_pass':'SR_pass'}
+# We also need to tell the toy generation method which postfit transfer function to use to produce the QCD estimate 
+# in all the non-fail regions. In this case, we are only fitting Loose -> Pass, so there should only be one function
+rpfs = [rpf_dict[args.func]]
+# Now we can pass this all to the toy generation method, which will output a root file containing the histograms for:
+# 	- SR_loose (we want this to be blinded for now, since it's not entirely signal-free)
+#	- SR_pass
+twoD.MakePseudoData(regions, rpfs, findreplace, blindFail=True, poisson=True)
+

--- a/TwoDAlphabet/alphawrap.py
+++ b/TwoDAlphabet/alphawrap.py
@@ -354,6 +354,47 @@ class ParametricFunction(Generic2D):
                 break
         if parfound == False:
             raise RuntimeError('Could not find par%s in set of nuisances:\n\t%s'%(parIdx,[n['name'] for n in self.nuisances]))
+
+#class SemiParametricFunction(Generic2D):
+class SemiParametricFunction(ParametricFunction,Generic2D):
+    def __init__(self,name,inhist,binning,formula,constraints={},forcePositive=True,funcCeiling=10.):
+        '''A hybrid of ParametricFunction and BinnedDistribution classes. 
+        Uses former (RooFormulaVar) if bin count<funcCeiling, later (RooRealVar) if not.
+        Args: 
+            same as in Parametric Function and BinnedDistribution classes, except funcCeiling
+            funcCeiling (float, optional). Bins with content >funcCeiling will use floating bin parametrization
+        instead of a functional form. Enables using functional form only in the tails of the distribution. Defaults to 10
+        '''
+        Generic2D.__init__(self,name,binning,forcePositive)
+        self.formula = formula #This is already done in init
+        self.nuisances = self._createFuncVars(constraints)
+        self.arglist = RooArgList()
+        for n in self.nuisances: self.arglist.add(n['obj'])
+
+        for cat in _subspace:
+            cat_name = name+'_'+cat
+            cat_hist = copy_hist_with_new_bins(cat_name,'X',inhist,self.binning.xbinByCat[cat])
+            for ybin in range(1,cat_hist.GetNbinsY()+1):
+                for xbin in range(1,cat_hist.GetNbinsX()+1):
+                    content = cat_hist.GetBinContent(xbin,ybin)
+                    bin_name = '%s_bin_%s-%s'%(cat_name,xbin,ybin)
+                    if(content<funcCeiling):
+                        xConst,yConst = self.mappedBinCenter(xbin,ybin,cat)
+                        if forcePositive: 
+                            final_formula = "max(1e-9,%s)"%(self._replaceXY(xConst,yConst))
+                        else:             
+                            final_formula = self._replaceXY(xConst,yConst)
+
+                        self.binVars[bin_name] = RooFormulaVar(
+                            bin_name, bin_name,
+                            final_formula,
+                            self.arglist
+                        )
+                    else:
+                        self.binVars[bin_name] = RooRealVar(bin_name, bin_name, content, 1e-6, 1e9)
+                        self.nuisances.append({'name':bin_name, 'constraint':'flatParam', 'obj': self.binVars[bin_name]})
+
+
        
 class BinnedDistribution(Generic2D):
     def __init__(self,name,inhist,binning,constant=False,forcePositive=True):

--- a/TwoDAlphabet/alphawrap.py
+++ b/TwoDAlphabet/alphawrap.py
@@ -378,7 +378,7 @@ class BinnedDistribution(Generic2D):
                     if constant or self._nSurroundingZeros(cat_hist,xbin,ybin) > 7:
                         self.binVars[bin_name] = RooConstVar(bin_name, bin_name, cat_hist.GetBinContent(xbin,ybin))
                     else:
-                        self.binVars[bin_name] = RooRealVar(bin_name, bin_name, max(5,cat_hist.GetBinContent(xbin,ybin)), 1e-6, 1e6)
+                        self.binVars[bin_name] = RooRealVar(bin_name, bin_name, max(5,cat_hist.GetBinContent(xbin,ybin)), 1e-6, 1e9)
                         self.nuisances.append({'name':bin_name, 'constraint':'flatParam', 'obj': self.binVars[bin_name]})
                     self._varStorage.append(self.binVars[bin_name]) # For safety if we add shape templates            
                      

--- a/TwoDAlphabet/alphawrap.py
+++ b/TwoDAlphabet/alphawrap.py
@@ -463,7 +463,7 @@ class BinnedDistribution(Generic2D):
             for ybin in range(1,cat_hist_up.GetNbinsY()+1):
                 for xbin in range(1,cat_hist_up.GetNbinsX()+1):
                     bin_name = '%s_%s_bin_%s-%s'%(cat_name,nuis_name,xbin,ybin)
-                    self.binVar[bin_name] = singleBinInterp( # change to singleBinInterpQuad to change interpolation method
+                    self.binVars[bin_name] = singleBinInterp( # change to singleBinInterpQuad to change interpolation method
                                                 bin_name, self.getBinVar(xbin,ybin,cat), nuisance_par,
                                                 cat_hist_up.GetBinContent(xbin,ybin),
                                                 cat_hist_down.GetBinContent(xbin,ybin),

--- a/TwoDAlphabet/binning.py
+++ b/TwoDAlphabet/binning.py
@@ -369,7 +369,6 @@ def stitch_hists_in_x(name,binning,histList,blinded=[]):
         if i in blinded:
             bin_jump += histList[i].GetNbinsX()
             continue
-        
         for ybin in range(1,h.GetNbinsY()+1):
             for xbin in range(1,h.GetNbinsX()+1):
                 stitched_xindex = xbin + bin_jump

--- a/TwoDAlphabet/binning.py
+++ b/TwoDAlphabet/binning.py
@@ -206,15 +206,13 @@ def parse_binning_info(binDict):
     for v in ['X','Y']:
         axis = binDict[v]
         if (v == 'X') and ('LOW' in axis.keys()) and ('SIG' in axis.keys()) and ('HIGH' in axis.keys()):
-            new_bins = {c:parse_axis_info(axis[c]) for c in ['LOW','SIG','HIGH']}
+            new_bins_rounded = {c:parse_axis_info(axis[c]) for c in ['LOW','SIG','HIGH']}
         else:
             new_bins = parse_axis_info(axis)
-
-	# deal with rounding issues
-	new_bins_rounded = [round(i,2) for i in new_bins]
+            new_bins_rounded = [round(i,2) for i in new_bins]
             
         if v == 'X':
-            if isinstance(new_bins,list):
+            if isinstance(new_bins_rounded,list):
                 newXbins = binlist_to_bindict(new_bins_rounded,axis['SIGSTART'],axis['SIGEND'])
             else:
                 newXbins = new_bins_rounded
@@ -307,9 +305,9 @@ def concat_bin_lists(binLists):
         if b[0] != bins_list[-1]:
             raise ValueError('Bins in binLists are not continuous along axis.')
         bins_list.extend(b[1:])
-	#print('bin: {}'.format(b[1:]))
-	#print('bin rounded: {}'.format(round(b[1:],2)))
-	#bins_list.extend(round(b[1:],2))
+    #print('bin: {}'.format(b[1:]))
+    #print('bin rounded: {}'.format(round(b[1:],2)))
+    #bins_list.extend(round(b[1:],2))
     return bins_list
 
 def get_bins_from_hist(XYZ,h):

--- a/TwoDAlphabet/binning.py
+++ b/TwoDAlphabet/binning.py
@@ -456,13 +456,13 @@ def copy_hist_with_new_bins(copyName,XorY,inHist,new_bins):
         for rebin in range(1,rebin_nbins+1):
             new_bin_content = 0
             new_bin_errorsq = 0
-            new_bin_min = rebin_axis.GetBinLowEdge(rebin)
-            new_bin_max = rebin_axis.GetBinUpEdge(rebin)
+            new_bin_min = round(rebin_axis.GetBinLowEdge(rebin), 2)
+            new_bin_max = round(rebin_axis.GetBinUpEdge(rebin), 2)
 
             # print '\t New bin x: ' + str(newBinX) + ', ' + str(newBinXlow) + ', ' + str(newBinXhigh)
             for old_bin in range(1,old_axis.GetNbins()+1):
-                old_bin_min = old_axis.GetBinLowEdge(old_bin)
-                old_bin_max = old_axis.GetBinUpEdge(old_bin)
+                old_bin_min = round(old_axis.GetBinLowEdge(old_bin), 2)
+                old_bin_max = round(old_axis.GetBinUpEdge(old_bin), 2)
                 if old_bin_min >= new_bin_max:
                     break
                 elif old_bin_min >= new_bin_min and old_bin_min < new_bin_max:
@@ -470,9 +470,11 @@ def copy_hist_with_new_bins(copyName,XorY,inHist,new_bins):
                         if axis_to_rebin == "X":
                             new_bin_content += inHist.GetBinContent(old_bin,static_bin)
                             new_bin_errorsq += inHist.GetBinError(old_bin,static_bin)**2
+                            break
                         else:
                             new_bin_content += inHist.GetBinContent(static_bin,old_bin)
                             new_bin_errorsq += inHist.GetBinError(static_bin,old_bin)**2
+                            break
                     elif old_bin_max > new_bin_max:
                         raise ValueError(
                             '''The requested %s rebinning does not align bin edges with the input bin edge.

--- a/TwoDAlphabet/binning.py
+++ b/TwoDAlphabet/binning.py
@@ -304,6 +304,9 @@ def concat_bin_lists(binLists):
         if b[0] != bins_list[-1]:
             raise ValueError('Bins in binLists are not continuous along axis.')
         bins_list.extend(b[1:])
+	#print('bin: {}'.format(b[1:]))
+	#print('bin rounded: {}'.format(round(b[1:],2)))
+	#bins_list.extend(round(b[1:],2))
     return bins_list
 
 def get_bins_from_hist(XYZ,h):
@@ -319,7 +322,8 @@ def get_bins_from_hist(XYZ,h):
     '''
     nbins = getattr(h,'GetNbins'+XYZ)()
     axis = getattr(h,'Get%saxis'%XYZ)()
-    bins = [axis.GetBinLowEdge(i+1) for i in range(nbins)]+[axis.GetBinUpEdge(nbins)]
+    # bins = [axis.GetBinLowEdge(i+1) for i in range(nbins)]+[axis.GetBinUpEdge(nbins)]
+    bins = [round(axis.GetBinLowEdge(i+1),2) for i in range(nbins)]+[round(axis.GetBinUpEdge(nbins),2)]
     return bins
 
 def histlist_to_binlist(XYZ,histList):

--- a/TwoDAlphabet/binning.py
+++ b/TwoDAlphabet/binning.py
@@ -209,13 +209,16 @@ def parse_binning_info(binDict):
             new_bins = {c:parse_axis_info(axis[c]) for c in ['LOW','SIG','HIGH']}
         else:
             new_bins = parse_axis_info(axis)
+
+	# deal with rounding issues
+	new_bins_rounded = [round(i,2) for i in new_bins]
             
         if v == 'X':
             if isinstance(new_bins,list):
-                newXbins = binlist_to_bindict(new_bins,axis['SIGSTART'],axis['SIGEND'])
+                newXbins = binlist_to_bindict(new_bins_rounded,axis['SIGSTART'],axis['SIGEND'])
             else:
-                newXbins = new_bins
-        elif v == 'Y': newYbins = new_bins
+                newXbins = new_bins_rounded
+        elif v == 'Y': newYbins = new_bins_rounded
 
     return newXbins,newYbins
     

--- a/TwoDAlphabet/config.py
+++ b/TwoDAlphabet/config.py
@@ -221,8 +221,9 @@ class Config:
                     {'color': nan if 'COLOR' not in info else info['COLOR'],
                     'process_type': info['TYPE'],
                     'scale': 1.0 if 'SCALE' not in info else info['SCALE'],
-                    'source_filename': info['LOC'].split(':')[0],
-                    'source_histname': info['LOC'].split(':')[1],
+		    # Need to check if user requests files hosted remotely via xrootd redirector
+                    'source_filename': info['LOC'].split(':')[0] if 'root://' not in info['LOC'] else info['LOC'].split(':')[0]+':'+info['LOC'].split(':')[1],
+                    'source_histname': info['LOC'].split(':')[1] if 'root://' not in info['LOC'] else info['LOC'].split(':')[2],
                     'alias': info['NAME'] if 'ALIAS' not in info.keys() else info['ALIAS'], #in file name
                     'title': info['NAME'] if 'TITLE' not in info.keys() else info['TITLE'], #in legend entry
                     'variation': info['VARIATION'],
@@ -381,6 +382,7 @@ class OrganizedHists():
             None
         '''
         for infilename,histdf in self.hist_map.items():
+	    print('opening {}'.format(infilename))
             infile = ROOT.TFile.Open(infilename)
             for row in histdf.itertuples():
                 if row.source_histname not in [k.GetName() for k in infile.GetListOfKeys()]:
@@ -517,15 +519,15 @@ def _get_syst_attrs(name,syst_dict):
             {
                 'shapes':syst_dict['SIGMA'],
                 'syst_type': 'shapes',
-                'source_filename': syst_dict['UP'].split(':')[0],
-                'source_histname': syst_dict['UP'].split(':')[1],
+                'source_filename': syst_dict['UP'].split(':')[0] if 'root://' not in syst_dict['UP'] else syst_dict['UP'].split(':')[0]+':'+syst_dict['UP'].split(':')[1],
+                'source_histname': syst_dict['UP'].split(':')[1] if 'root://' not in syst_dict['UP'] else syst_dict['UP'].split(':')[2],
                 'direction': 'Up',
                 'variation_alias': name if 'ALIAS' not in syst_dict else syst_dict['ALIAS']
             }, {
                 'shapes':syst_dict['SIGMA'],
                 'syst_type': 'shapes',
-                'source_filename': syst_dict['DOWN'].split(':')[0],
-                'source_histname': syst_dict['DOWN'].split(':')[1],
+                'source_filename': syst_dict['DOWN'].split(':')[0] if 'root://' not in syst_dict['DOWN'] else syst_dict['DOWN'].split(':')[0]+':'+syst_dict['DOWN'].split(':')[1],
+                'source_histname': syst_dict['DOWN'].split(':')[1] if 'root://' not in syst_dict['DOWN'] else syst_dict['DOWN'].split(':')[2],
                 'direction': 'Down',
                 'variation_alias': name if 'ALIAS' not in syst_dict else syst_dict['ALIAS']
             }

--- a/TwoDAlphabet/plot.py
+++ b/TwoDAlphabet/plot.py
@@ -770,9 +770,12 @@ def make_systematic_plots(twoD):
         for axis in ['X','Y']:
             nominal = getattr(nominal_full,'Projection'+axis)('%s_%s_%s_%s'%(p,r,'nom','proj'+axis))
             for s in twoD.ledger.GetShapeSystematics(drop_norms=True):
-                up = getattr(twoD.organizedHists.Get(process=p,region=r,systematic=s+'Up'),'Projection'+axis)('%s_%s_%s_%s'%(p,r,s+'Up','proj'+axis))
-                down = getattr(twoD.organizedHists.Get(process=p,region=r,systematic=s+'Down'),'Projection'+axis)('%s_%s_%s_%s'%(p,r,s+'Down','proj'+axis))
-
+                try:
+                    up = getattr(twoD.organizedHists.Get(process=p,region=r,systematic=s+'Up'),'Projection'+axis)('%s_%s_%s_%s'%(p,r,s+'Up','proj'+axis))
+                    down = getattr(twoD.organizedHists.Get(process=p,region=r,systematic=s+'Down'),'Projection'+axis)('%s_%s_%s_%s'%(p,r,s+'Down','proj'+axis))
+                except:
+                    print("Skipping systematic {0} for process {1} (region {2})".format(s,p,r))
+                    continue
                 c.cd()
                 nominal.SetLineColor(ROOT.kBlack)
                 nominal.SetFillColor(ROOT.kYellow-9)

--- a/TwoDAlphabet/plot.py
+++ b/TwoDAlphabet/plot.py
@@ -808,6 +808,10 @@ def _make_pull_plot(data, bkg):
     for ibin in range(1,pull.GetNbinsX()+1):
         d = data.GetBinContent(ibin)
         b = bkg.GetBinContent(ibin)
+	#DEBUG
+	print('b: {}'.format(b))
+	print('d: {}'.format(d))
+	print('type(d) = {}'.format(type(d)))
         if d >= b:
             derr = data.GetBinErrorLow(ibin)
             berr = bkg.GetBinErrorUp(ibin)
@@ -818,7 +822,13 @@ def _make_pull_plot(data, bkg):
         if d == 0:
             derr = 1
 
+	# DEBUG
+	if math.isnan(d):
+	    derr = 1	
+	    berr = 1
+
         sigma = math.sqrt(derr*derr + berr*berr)
+
         if sigma != 0:
             pull.SetBinContent(ibin, (pull.GetBinContent(ibin))/sigma)
         else:

--- a/TwoDAlphabet/plot.py
+++ b/TwoDAlphabet/plot.py
@@ -1009,10 +1009,10 @@ def plot_gof(tag, subtag, seed=123456, condor=False):
 
         # Write out for reference
         with open('gof_results.txt','w') as out:
-            out.write('Test statistic in data = '+str(gof_data))
-            out.write('Mean from toys = '+str(gaus.GetParameter(1)))
-            out.write('Width from toys = '+str(gaus.GetParameter(2)))
-            out.write('p-value = '+str(pvalue))
+            out.write('Test statistic in data = {}\n'.format(str(gof_data)))
+            out.write('Mean from toys = {}\n'.format(str(gaus.GetParameter(1))))
+            out.write('Width from toys = {}\n'.format(str(gaus.GetParameter(2))))
+            out.write('p-value = {}\n'.format(str(pvalue)))
 
         # Extend the axis if needed
         if htoy_gof.GetXaxis().GetXmax() < gof_data:

--- a/TwoDAlphabet/twoDalphabet.py
+++ b/TwoDAlphabet/twoDalphabet.py
@@ -459,24 +459,30 @@ class TwoDAlphabet:
 	template_file = ROOT.TFile.Open(self.df.iloc[0].source_filename)
 	template = template_file.Get(self.df.iloc[0].source_histname)
 	template.SetDirectory(0)
+	print(template.GetTitle())
 	numX, numY = template.GetNbinsX(), template.GetNbinsY()
 	xMin, yMin = template.GetXaxis().GetXmin(), template.GetYaxis().GetXmin()
 	xMax, yMax = template.GetXaxis().GetXmax(), template.GetYaxis().GetXmax()
+	print(numX,numY)
+	print(xMin,yMin)
+	print(xMax,yMax)
 
-	# Now get the original config to modify it 
+	# Now get the original config to modify it
 	config = Config(jsonPath='{}/runConfig.json'.format(self.tag))
 	if binName not in config.config['BINNING']:
 	    raise RuntimeError('Binning label "{}" not in list of labels in JSON: {}'.format(binName,config.config['BINNING'].keys()))
 	binning = config.config['BINNING'][binName].copy()  # {X:info, Y:info}
+	print(binning)
 	for axis in ['X','Y']:
 	    # Remove custom bin widths, if used
 	    if 'BINS' in binning[axis]:
 		binning[axis].pop('BINS')
 	    # Add in the new info
 	    binning[axis]["NBINS"] = numX if axis == 'X' else numY
-	    binning[axis]["MIN"] = xMin if axis == 'X' else xMin
-	    binning[axis]["MAX"] = xMax if axis == 'X' else xMax
+	    binning[axis]["MIN"] = xMin if axis == 'X' else yMin
+	    binning[axis]["MAX"] = xMax if axis == 'X' else yMax
 
+	print(binning)
         rpfFile = ROOT.TFile.Open('{}/RPF_data.root'.format(self.tag),'RECREATE')
         rpfFile.cd()
 

--- a/TwoDAlphabet/twoDalphabet.py
+++ b/TwoDAlphabet/twoDalphabet.py
@@ -506,6 +506,13 @@ class TwoDAlphabet:
 	rpfFile.Close()
 	return outHists
 
+    def MakePseudoData(self, subtag, regions=[], rpfs=[], b_or_s='b'):
+	'''TO DO:
+	    - write code in TwoDAlphabet/utils/make_pseudo.py
+	    - import it as module, 
+	    - implement it here
+	'''
+
     def GoodnessOfFit(self, subtag, ntoys, card_or_w='card.txt', freezeSignal=False, seed=123456,
                             verbosity=0, extra='', condor=False, eosRootfiles=None, njobs=0, makeEnv=False):
         # NOTE: There's no way to blind data here - need to evaluate it to get the p-value

--- a/TwoDAlphabet/twoDalphabet.py
+++ b/TwoDAlphabet/twoDalphabet.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from TwoDAlphabet.config import Config, OrganizedHists
 from TwoDAlphabet.binning import Binning
 from TwoDAlphabet.helpers import CondorRunner, execute_cmd, parse_arg_dict, unpack_to_line, make_RDH, cd, _combineTool_impacts_fix
-from TwoDAlphabet.alphawrap import Generic2D
+from TwoDAlphabet.alphawrap import Generic2D, ParametricFunction
 from TwoDAlphabet import plot
 import ROOT
 
@@ -424,6 +424,87 @@ class TwoDAlphabet:
         f.Close()
 
         return masked_regions
+
+    def GetTransferFunctionShapes(self, binName='default', rpfOpts={}):
+	'''Get the histograms for the transfer functions used in the fit. The histograms will have the same binning as the input histograms to 2DAlphabet, not the rebinned form.
+	NOTE: the ML fit must have been run first in order to access the `rpf_params*.txt` file containing the postfit parameter values.
+	
+        Args:
+	    binName (str): binning label in the `BINNING` section of the JSON
+	    rpfOpts dict(str:dict): map containing the name of the transfer function(s) (e.g. '2x2' and the associated form (e.g. '@0+@1*x') and constraints
+
+        Returns:
+	    outHists (list): list containing histograms of the transfer function(s) constructed using the b-only and s+b postfit values, in the original input binning
+	'''
+	# Determine which fit directories (subtags, in 2DAlphabet) exist and have a valid fit result
+	subDirs = next(os.walk(self.tag))[1]
+	subtags = []
+	for subDir in subDirs:
+	    if os.path.isfile('{}/{}/postfitshapes_s.root'.format(self.tag,subDir)):
+		subtags.append(subDir)
+
+	# Get the input histogram binning (X and Y min/max, nbins)
+	template_file = ROOT.TFile.Open(self.df.iloc[0].source_filename)
+	template = template_file.Get(self.df.iloc[0].source_histname)
+	template.SetDirectory(0)
+	numX, numY = template.GetNbinsX(), template.GetNbinsY()
+	xMin, yMin = template.GetXaxis().GetXmin(), template.GetYaxis().GetXmin()
+	xMax, yMax = template.GetXaxis().GetXmax(), template.GetYaxis().GetXmax()
+
+	# Now get the original config to modify it 
+	config = Config(jsonPath='{}/runConfig.json'.format(self.tag))
+	if binName not in config.config['BINNING']:
+	    raise RuntimeError('Binning label "{}" not in list of labels in JSON: {}'.format(binName,config.config['BINNING'].keys()))
+	binning = config.config['BINNING'][binName].copy()  # {X:info, Y:info}
+	for axis in ['X','Y']:
+	    # Remove custom bin widths, if used
+	    if 'BINS' in binning[axis]:
+		binning[axis].pop('BINS')
+	    # Add in the new info
+	    binning[axis]["NBINS"] = numX if axis == 'X' else numY
+	    binning[axis]["MIN"] = xMin if axis == 'X' else xMin
+	    binning[axis]["MAX"] = xMax if axis == 'X' else xMax
+
+        rpfFile = ROOT.TFile.Open('{}/RPF_data.root'.format(self.tag),'RECREATE')
+        rpfFile.cd()
+
+	outHists = []
+
+        # Now, prepare to create the ParametricFunction object(s)
+	newBinning = Binning(binName, binning, template)
+	for rpf in rpfOpts.keys():
+	    for fitType in ['b','s']:
+		subtag = [tag for tag in subtags if rpf in tag]
+		if len(subtag) != 1:
+		    raise ValueError('{} valid subtags found: {}\nNot supported.'.format(len(subtag),subtag))
+		rpf_params = self.GetParamsOnMatch(regex='_par', subtag=subtag[0], b_or_s=fitType)
+		rpf_func = ParametricFunction(
+		    rpf+fitType, newBinning, rpfOpts[rpf]['form'],
+		    constraints=rpfOpts[rpf]['constraints']
+		)
+
+	        # Check to ensure that the number of params matches what was given for the transfer function form
+		if rpfOpts[rpf]['form'].count('@') != len(rpf_params):
+		    raise RuntimeError('Transfer function {} : {} has {} parameters, detected {} parameters on regex match:\n{}'.format(rpf,rpfOpts[rpf]['form'],rpfOpts[rpf]['form'].count('@'),len(rpf_params),rpf_params.keys()))
+		# Set the parameter values in the rpf_func ParametricFunction object
+		count = 0
+		for param, valError in rpf_params.items():
+		    nParam = param.split('_par')[-1] # grab the parameter number
+		    rpf_func.setFuncParam('{}{}_par{}'.format(rpf,fitType,nParam), valError['val'])
+
+		# Create and fill the RPF shape histogram
+		out_hist = rpf_func.binning.CreateHist(fitType+'_'+rpf,cat='')
+		for ix in range(1, numX):
+		    for iy in range(1, numY):
+			out_hist.SetBinContent(ix, iy, rpf_func.getBinVal(ix, iy))
+
+		rpfFile.cd()
+		out_hist.SetDirectory(0)
+		out_hist.Write()
+		outHists.append(out_hist)
+
+	rpfFile.Close()
+	return outHists
 
     def GoodnessOfFit(self, subtag, ntoys, card_or_w='card.txt', freezeSignal=False, seed=123456,
                             verbosity=0, extra='', condor=False, eosRootfiles=None, njobs=0, makeEnv=False):

--- a/TwoDAlphabet/twoDalphabet.py
+++ b/TwoDAlphabet/twoDalphabet.py
@@ -459,20 +459,15 @@ class TwoDAlphabet:
 	template_file = ROOT.TFile.Open(self.df.iloc[0].source_filename)
 	template = template_file.Get(self.df.iloc[0].source_histname)
 	template.SetDirectory(0)
-	print(template.GetTitle())
 	numX, numY = template.GetNbinsX(), template.GetNbinsY()
 	xMin, yMin = template.GetXaxis().GetXmin(), template.GetYaxis().GetXmin()
 	xMax, yMax = template.GetXaxis().GetXmax(), template.GetYaxis().GetXmax()
-	print(numX,numY)
-	print(xMin,yMin)
-	print(xMax,yMax)
 
 	# Now get the original config to modify it
 	config = Config(jsonPath='{}/runConfig.json'.format(self.tag))
 	if binName not in config.config['BINNING']:
 	    raise RuntimeError('Binning label "{}" not in list of labels in JSON: {}'.format(binName,config.config['BINNING'].keys()))
 	binning = config.config['BINNING'][binName].copy()  # {X:info, Y:info}
-	print(binning)
 	for axis in ['X','Y']:
 	    # Remove custom bin widths, if used
 	    if 'BINS' in binning[axis]:
@@ -482,7 +477,6 @@ class TwoDAlphabet:
 	    binning[axis]["MIN"] = xMin if axis == 'X' else yMin
 	    binning[axis]["MAX"] = xMax if axis == 'X' else yMax
 
-	print(binning)
         rpfFile = ROOT.TFile.Open('{}/RPF_data.root'.format(self.tag),'RECREATE')
         rpfFile.cd()
 

--- a/TwoDAlphabet/utils/make_pseudo.py
+++ b/TwoDAlphabet/utils/make_pseudo.py
@@ -1,0 +1,233 @@
+'''make_pseudo.py
+
+Module containing the functionality for producing a pseudo-data toy in the given regions of a 2DAlphabet fit,
+using post-fit transfer functions to obtain the data-driven background estimates in the non-fail regions.
+
+'''
+import ROOT
+
+class PseudoData:
+    '''Class to produce pseudo data from a given set of regions and postfit transfer functions.'''
+    def __init__(self, twoD, subtag, regions=[], rpfs=[], findreplace={}, b_or_s='b'):
+	'''Creates a pseudodata toy in the given regions. Uses postfit transfer functions to obtain
+	the data-driven background estimates in the non-fail regions, from which background PDFs are 
+	generated and used to produce the toy data. 
+
+	Args:
+	    twoD (TwoDAlphabet): TwoDAlphabet object containing all information on the workspace
+            subtag (str): The name of the workspace sub-directory containing the fit results
+            regions (list(str)): List containing the names of the regions to be created, in the order
+		in which the transfer functions would be applied. E.g., 'Fail', 'Loose', 'Pass'
+            rpfs (list(TH2)): List containing the 2D histograms of the postfit transfer functions used, 
+		in the order in which they were applied in the fit.
+	    findreplace (dict): Non-nested dictionary with key-value pairs to find-replace in the TwoDAlphabet
+		internal ledger.
+            b_or_s (str): Whether to use the postfit background-only ('b') or signal+bkg ('s') transfer function
+	'''
+	self.twoD = twoD
+	self.tag = twoD.tag
+	self.subtag = subtag
+	self.regions = regions
+	self.rpfs = rpfs
+	self.b_or_s = b_or_s
+	# Create the dataframe with information on the nominal backgrounds and data files and histograms
+	self.df = self.select(_select_nominal, regions)
+	# Find and replace the source histogram names from, e.g., control region to signal region 
+	if findreplace:
+	    for find, replace in findreplace:
+		self.df['source_histname'] = self.df['source_histname'].apply(lambda x: x.replace(find, replace))
+	else:
+	    # Check that a find-replace doesn't need to be performed
+	    for i in range(len(self.df)):
+		if not any([region in self.df.iloc[i].source_histname for region in self.regions]):
+		    raise RuntimeError('Region names {} not found source in histogram {} for file {}. Run with the appropriate findreplace argument if you need to generate toys for regions which have not yet been fitted.'.format(self.regions, self.df.iloc[i].source_histname, self.df.iloc[i].source_filename))
+	# Check that the number of regions and transfer functions makes sense
+	if (len(regions)-len(rpfs)) != 1:
+	    raise RuntimeError('There must be exactly 1 fewer transfer functions than regions between which to transfer.')
+
+    def _select_nominal(row, args):
+        '''Helper function to get only the Data and nominal background files+histos in the given fit regions'''
+        regions = args[0]
+        if row.region not in regions: return False
+        elif row.process_type == 'DATA': return True
+        elif row.process_type == 'BKG':
+            if row.variation == 'nominal': return True
+            else: return False
+        else: return False
+
+    def select(self, func, *args):
+        '''Returns DataFrame containing the rows and columns selected by a lambda function'''
+        eval_lambda = lambda row: func(row, args)
+        df = self.twoD.ledger.df.loc[self.twoD.ledger.df.apply(eval_lambda,axis=1)]
+        return df
+
+    def GetFailTemplate(self):
+	'''Subtract all MC background histograms from the data fail histogram and return the data-minus-bkg estimate.'''
+	data_file = ROOT.TFile.Open(self.df.iloc[0].source_filename)
+	data_hist = data_file.Get(self.df.iloc[0].source_histname)
+	if (self.regions[0] not in data_hist.GetName()):
+	    raise RuntimeError('Fail region {} not in data histogram name {}'.format(self.regions[0], data_hist.GetName()))
+	bkg_est = data_hist.Clone('fail_bkg_est')
+	bkg_est.SetDirectory(0)
+	data_file.Close()
+	print('Determining data minus background estimate in {}'.format(self.regions[0]))
+	for region, group in self.df.groupby('region'):
+	    if region != self.regions[0]: continue
+	    bkg_sources = group.loc[group.process_type.eq('BKG')]
+	    for i in range(len(bkg_sources)):
+		bkg_file = ROOT.TFile.Open(bkg_sources.iloc[i].source_filename)
+		bkg_hist = bkg_file.Get(bkg_sources.iloc[i].source_histname)
+		print('Subtracting background {} from data in {}'.format(bkg_sources.iloc[i].process, region))
+		bkg_est.Add(bkg_hist, -1)
+		bkg_file.Close()
+	return bkg_est
+
+    def GetBkgTemplates(self):
+	'''Gets the summed backgrounds in each of the regions'''
+	out = {}
+        template_file = ROOT.TFile.Open(self.df.iloc[0].source_filename)
+        template_hist = data_file.Get(self.df.iloc[0].source_histname)
+	template_hist.SetDirectory(0)
+	template_file.Close()
+	for region in self.regions[1:]: # skip the fail region
+	    print('Determining total MC background in {}'.format(region))
+	    template = template_hist.Clone('TotalBkg_{}'.format(region))
+	    template.Reset()
+	    bkg_sources = self.df.loc[self.df.region.eq(region) & self.df.process_type.eq('BKG')]
+	    for i in range(len(bkg_sources)):
+                bkg_file = ROOT.TFile.Open(bkg_sources.iloc[i].source_filename)
+                bkg_hist = bkg_file.Get(bkg_sources.iloc[i].source_histname)
+		template.Add(bkg_hist)
+		bkg_file.Close()
+		out[region] = bkg_hist
+	return out
+
+    def GetAsimov(self, fail_template, bkg_templates):
+	'''Constructs the data-driven background estimate in the non-fail regions from the
+	product of the data-driven fail template and the transfer functions.
+
+	Args:
+	    fail_template (TH2): TH2 representing the data-bkg fail region estimate
+	    bkg_templates (dict(TH2)): dictionary containing the key-value region name and 
+		associated total MC background TH2
+
+	Returns:
+	    asimov (dict): key-value region name and associated total background (Asimov dataset)
+	    transfers (dict): key-value region name and associated transfer function-based estimate
+	'''
+	# Find out how many transfers need to be performed
+	nTransfers = len(self.regions)-1
+	assert(nTransfers>=1,'There must be at least one transfer') # this should already be caught by now, but just in case
+	# Get the total MC bkg distributions to which the transfer function-based estimates will be added
+	asimov = bkg_templates.copy()
+	transfers = {}
+
+	for i, region in enumerate(self.regions[1:]): # skip the fail region
+	    print('Performing transfer {}'.format(i+1))
+            CurrentRegionIndex = self.regions.index(region)
+            PreviousRegionIndex = CurrentRegionIndex - 1
+	    PreviousRegionName = self.regions[PreviousRegionIndex]
+	    TransferFuncName = self.rpfs[i].GetName()
+	    outName = '{}_{}'.format(PreviousRegionName, TransferFuncName)
+	    # Get the transfer-based estimate
+	    if (i==0): # Performing the first transfer
+		transferN = self.Multiply(fail_template, self.rpfs[i], outName)
+	    else:
+		CurrentRegionIndex = self.regions.index(region)
+		PreviousRegionIndex = CurrentRegionIndex - 1
+		transferN = self.Multiply(transfers[PreviousRegionName], self.rpfs[i], outName)
+	    transferN.SetDirectory(0)
+	    # Store the transfer-based estimate in case there is more than one transfer
+	    transfers[region] = transferN
+	    # Add the transfer-based bkg estimate to the total MC-based bkg estimate
+	    asimov[region].Add(transferN)	
+
+	return asimov, transfers
+
+    def CreatePDF(self, asimovDatasets):
+	'''Normalizes Asimov background distribution to unity to create a background PDF
+
+	Args:
+	    asimovDatasets (dict): key-value region name and associated total background distribution
+
+	Returns:
+	    PDFs (dict): key-value region name and associated total background PDF and number of events
+	'''
+	PDFs = {}
+	for region, asimovDataset in asimovDatasets.items():
+	    PDF = asimovDatasets[region].Clone('pdf_{}'.format(region))
+	    PDF.SetDirectory(0)
+	    nEvents = PDF.Integral(1,PDF.GetNbinsX()+1,1,PDF.GetNbinsY()+1)
+	    PDF.Scale(1./nEvents)
+	    PDFs[region] = [PDF, nEvents]
+	return PDFs
+
+    def CreateCDF(self, PDFs):
+	'''Creates the cumulative distribution function for each region, based on the background PDF'''
+	CDFs = {}
+	for region, PDF in PDFs.items():
+	    nx = PDF.GetNbinsX()
+	    ny = PDF.GetNbinsY()
+	    CDF = ROOT.TH1F('CDF_{}'.format(region))
+	    CDF.SetDirectory(0)
+	    cumulativeBin = 0
+	    for i in range(1,nx+1):
+		for j in range(1,ny+1):
+		    cumulativeBin += 1
+		    PDFval = PDF.GetBinContent(i,j) + CDF.GetBinContent(cumulativeBin-1)
+		    CDF.SetBinContent(cumulativeBin, PDFval)
+	    CDFs[region] = CDF
+	return CDFs
+
+    def FindPDFintersection(self, rand, CDF):
+	'''Returns the global bin corresponding to the CDF intersection'''
+	found = False
+	for i in range(1, CDF.GetNbinsX()+1):
+	    PDFval = CDF.GetBinContent(i)
+	    if (PDFval > rand):
+		return i
+	if not found:
+	    raise ValueError('Intersection with CDF not found, something is wrong. Make sure that the random number is bounded by the maximum value found in the CDF')
+
+    def GlobalBinTo2D(self, globalBin):
+	'''Converts the global bin (from the CDF intersection) to the 2D PDF bin
+	globalBins start from 1
+	globalBin 1 = (1,1), 2 = (1,2), and so on
+	'''
+	globalBin = globalBin - 1
+	NX = PDF.GetBinsX()
+	NY = PDF.GetBinsY()
+	localX = int(globalBin)/int(NY) + 1
+	localY = globalBin % NY + 1
+	return localX, localY
+
+    def GeneratePseudoData(self, PDF, nEvents, CDF, name):
+	'''
+
+	'''
+
+
+    def Multiply(self, h1, h2, name=''):
+    '''Modified version of TH2::Multiply() which additionally zeroes negative bins'''
+	print('Multiplying {} x {}'.format(h1.GetName(),h2.GetName()))
+	nh1 = (h1.GetNbinsX(),h1.GetNbinsY())
+	nh2 = (h2.GetNbinsX(),h2.GetNbinsY())
+	assert(nh1==nh2)
+	print('{} binning : {}\n{} binning : {}'.format(h1,nh1,h2,nh2))
+	finalHist = h1.Clone(name)
+	# loop over bins in h1
+	for i in range(0, h1.GetNbinsX()+1):
+	    for j in range(0, h1.GetNbinsY()+1):
+		h1Val = h1.GetBinContent(i,j)
+		if h1Val < 0:     # don't allow negative yields
+		    h1Val = 0
+		xVal = h1.GetXaxis().GetBinCenter(i)
+		yVal = h1.GetYaxis().GetBinCenter(j)
+		ih2 = h2.GetXaxis().FindBin(xVal)
+		jh2 = h2.GetYaxis().FindBin(yVal)
+		h2Val = h2.GetBinContent(ih2,jh2)
+		finalHist.SetBinContent(i,j,h1Val*h2Val)
+	finalHist.SetDirectory(0)
+	return finalHist
+
+    

--- a/TwoDAlphabet/utils/make_pseudo.py
+++ b/TwoDAlphabet/utils/make_pseudo.py
@@ -5,47 +5,54 @@ using post-fit transfer functions to obtain the data-driven background estimates
 
 '''
 import ROOT
+import random
 
 class PseudoData:
     '''Class to produce pseudo data from a given set of regions and postfit transfer functions.'''
-    def __init__(self, twoD, subtag, regions=[], rpfs=[], findreplace={}, b_or_s='b'):
+    def __init__(self, twoD, regions=[], rpfs=[], findreplace={}):
 	'''Creates a pseudodata toy in the given regions. Uses postfit transfer functions to obtain
 	the data-driven background estimates in the non-fail regions, from which background PDFs are 
 	generated and used to produce the toy data. 
 
 	Args:
 	    twoD (TwoDAlphabet): TwoDAlphabet object containing all information on the workspace
-            subtag (str): The name of the workspace sub-directory containing the fit results
             regions (list(str)): List containing the names of the regions to be created, in the order
 		in which the transfer functions would be applied. E.g., 'Fail', 'Loose', 'Pass'
             rpfs (list(TH2)): List containing the 2D histograms of the postfit transfer functions used, 
 		in the order in which they were applied in the fit.
 	    findreplace (dict): Non-nested dictionary with key-value pairs to find-replace in the TwoDAlphabet
 		internal ledger.
-            b_or_s (str): Whether to use the postfit background-only ('b') or signal+bkg ('s') transfer function
 	'''
 	self.twoD = twoD
+	self.ledger = self.twoD.ledger
 	self.tag = twoD.tag
-	self.subtag = subtag
 	self.regions = regions
 	self.rpfs = rpfs
-	self.b_or_s = b_or_s
-	# Create the dataframe with information on the nominal backgrounds and data files and histograms
-	self.df = self.select(_select_nominal, regions)
-	# Find and replace the source histogram names from, e.g., control region to signal region 
+	# Create the dataframe with information on the nominal backgrounds and data files and histograms, 
+	# either from the given regions or old regions if user needs to find and replace
 	if findreplace:
-	    for find, replace in findreplace:
-		self.df['source_histname'] = self.df['source_histname'].apply(lambda x: x.replace(find, replace))
+	    # need to use the original regions (that will be replaced)
+	    oldRegions = findreplace.keys()
+	    self.df = self.select(oldRegions)
+	    # Now find and replace the source histogram names from, e.g., control region to signal region
+	    for find, replace in findreplace.items():
+		#self.df['source_histname'] = self.df['source_histname'].apply(lambda x: x.replace(find, replace))
+		self.df = self.df.replace(find, replace, regex=True) # Modifies both `region` and `source_histname`
 	else:
 	    # Check that a find-replace doesn't need to be performed
 	    for i in range(len(self.df)):
 		if not any([region in self.df.iloc[i].source_histname for region in self.regions]):
 		    raise RuntimeError('Region names {} not found source in histogram {} for file {}. Run with the appropriate findreplace argument if you need to generate toys for regions which have not yet been fitted.'.format(self.regions, self.df.iloc[i].source_histname, self.df.iloc[i].source_filename))
+	    # If all is good, create internal dataframe from the given regions list
+	    self.df = self.df = self.select(self.regions)
 	# Check that the number of regions and transfer functions makes sense
 	if (len(regions)-len(rpfs)) != 1:
 	    raise RuntimeError('There must be exactly 1 fewer transfer functions than regions between which to transfer.')
+	# Get the output histogram names for the toy data in each region
+	self.outHistNames = self._getOutputHistNames(self.df)
+	self.nEvents = self._getNevents(self.df)
 
-    def _select_nominal(row, args):
+    def _select_nominal(self, row, args):
         '''Helper function to get only the Data and nominal background files+histos in the given fit regions'''
         regions = args[0]
         if row.region not in regions: return False
@@ -55,11 +62,46 @@ class PseudoData:
             else: return False
         else: return False
 
-    def select(self, func, *args):
+    def select(self, *args):
         '''Returns DataFrame containing the rows and columns selected by a lambda function'''
-        eval_lambda = lambda row: func(row, args)
-        df = self.twoD.ledger.df.loc[self.twoD.ledger.df.apply(eval_lambda,axis=1)]
+	def _select_nominal(row, args):
+	    regions = args[0]
+	    if row.region not in regions: return False
+	    elif row.process_type == 'DATA': return True
+	    elif row.process_type == 'BKG':
+		if row.variation == 'nominal': return True
+		else: return False
+	    else: return False
+        eval_lambda = lambda row: _select_nominal(row, args)
+        df = self.ledger.df.loc[self.ledger.df.apply(eval_lambda,axis=1)]
         return df
+
+    def _getOutputHistNames(self, df):
+	'''Gets the histogram names from the find-replaced dataframe ledger for the toy data output histograms'''
+	histnames = {} 
+	for region, group in df.groupby('region'):
+	    regionHistNames = group['source_histname'].drop_duplicates().to_list()
+	    if len(regionHistNames) != 1:
+		raise ValueError('There should only be one histogram name per region for data and nominal bkgs.')
+	    histnames[region] = regionHistNames[0]
+	return histnames
+
+    def _getNevents(self, df):
+        '''Searches through the internal dataframe and obtains the number of events IN DATA in each region.'''
+	nEvents = {}
+	for region, group in df.groupby('region'):
+	    data = df.loc[df.region.eq(region) & df.process_type.eq('DATA')]
+	    if (len(data) != 1):
+		raise RuntimeError('There should only be one data histogram per region')
+	    fName = data.iloc[0].source_filename
+	    hName = data.iloc[0].source_histname
+	    dataFile = ROOT.TFile.Open(fName,'READ')
+	    dataHist = dataFile.Get(hName)
+	    print('Obtaining total number of events in data in {}'.format(region))
+	    n = dataHist.Integral()
+	    nEvents[region] = n
+	    dataFile.Close()
+	return nEvents
 
     def GetFailTemplate(self):
 	'''Subtract all MC background histograms from the data fail histogram and return the data-minus-bkg estimate.'''
@@ -67,7 +109,9 @@ class PseudoData:
 	data_hist = data_file.Get(self.df.iloc[0].source_histname)
 	if (self.regions[0] not in data_hist.GetName()):
 	    raise RuntimeError('Fail region {} not in data histogram name {}'.format(self.regions[0], data_hist.GetName()))
-	bkg_est = data_hist.Clone('fail_bkg_est')
+	bkg_est = data_hist.Clone('fail_template_bkg_est')
+	fail_data = data_hist.Clone() # output the real fail data for future use
+	fail_data.SetDirectory(0)
 	bkg_est.SetDirectory(0)
 	data_file.Close()
 	print('Determining data minus background estimate in {}'.format(self.regions[0]))
@@ -80,13 +124,13 @@ class PseudoData:
 		print('Subtracting background {} from data in {}'.format(bkg_sources.iloc[i].process, region))
 		bkg_est.Add(bkg_hist, -1)
 		bkg_file.Close()
-	return bkg_est
+	return bkg_est, fail_data
 
     def GetBkgTemplates(self):
 	'''Gets the summed backgrounds in each of the regions'''
 	out = {}
         template_file = ROOT.TFile.Open(self.df.iloc[0].source_filename)
-        template_hist = data_file.Get(self.df.iloc[0].source_histname)
+        template_hist = template_file.Get(self.df.iloc[0].source_histname)
 	template_hist.SetDirectory(0)
 	template_file.Close()
 	for region in self.regions[1:]: # skip the fail region
@@ -117,13 +161,14 @@ class PseudoData:
 	'''
 	# Find out how many transfers need to be performed
 	nTransfers = len(self.regions)-1
-	assert(nTransfers>=1,'There must be at least one transfer') # this should already be caught by now, but just in case
+	if nTransfers<1:
+	    raise RuntimeError('There must be at least one transfer') # this should already be caught by now, but just in case
 	# Get the total MC bkg distributions to which the transfer function-based estimates will be added
 	asimov = bkg_templates.copy()
 	transfers = {}
 
 	for i, region in enumerate(self.regions[1:]): # skip the fail region
-	    print('Performing transfer {}'.format(i+1))
+	    print('Performing transfer {}:\n\t{} -> {}'.format(i+1, self.regions[i], self.regions[i+1]))
             CurrentRegionIndex = self.regions.index(region)
             PreviousRegionIndex = CurrentRegionIndex - 1
 	    PreviousRegionName = self.regions[PreviousRegionIndex]
@@ -152,23 +197,28 @@ class PseudoData:
 
 	Returns:
 	    PDFs (dict): key-value region name and associated total background PDF and number of events
+		in data, in that region.
 	'''
 	PDFs = {}
 	for region, asimovDataset in asimovDatasets.items():
 	    PDF = asimovDatasets[region].Clone('pdf_{}'.format(region))
 	    PDF.SetDirectory(0)
-	    nEvents = PDF.Integral(1,PDF.GetNbinsX()+1,1,PDF.GetNbinsY()+1)
-	    PDF.Scale(1./nEvents)
-	    PDFs[region] = [PDF, nEvents]
+	    # The PDF must be scaled by the integral of teh *Asimov* dataset, but this is *NOT* the number of
+	    # events that should be generated, since that is not representative of the number of events in the
+	    # actual dataset, which is what we are trying to model
+	    nEventsAsimov = PDF.Integral(1, PDF.GetNbinsX()+1, 1, PDF.GetNbinsY()+1)
+	    PDF.Scale(1./nEventsAsimov)
+	    PDFs[region] = [PDF, self.nEvents[region]] # return the actual number 
 	return PDFs
 
     def CreateCDF(self, PDFs):
 	'''Creates the cumulative distribution function for each region, based on the background PDF'''
 	CDFs = {}
 	for region, PDF in PDFs.items():
+	    PDF = PDF[0] # just want the PDF histogram, not nEvents
 	    nx = PDF.GetNbinsX()
 	    ny = PDF.GetNbinsY()
-	    CDF = ROOT.TH1F('CDF_{}'.format(region))
+	    CDF = ROOT.TH1F('CDF_{}'.format(region),"",nx*ny,0,nx*ny)
 	    CDF.SetDirectory(0)
 	    cumulativeBin = 0
 	    for i in range(1,nx+1):
@@ -176,44 +226,57 @@ class PseudoData:
 		    cumulativeBin += 1
 		    PDFval = PDF.GetBinContent(i,j) + CDF.GetBinContent(cumulativeBin-1)
 		    CDF.SetBinContent(cumulativeBin, PDFval)
+	    # Check that the CDF is bounded within [0, 1)
+	    if (CDF.GetMaximum() > 1.0):
+		raise ValueError('CDF maximum ({}) > 1.0 - something has gone wrong'.format(CDF.GetMaximum()))
 	    CDFs[region] = CDF
 	return CDFs
 
-    def FindPDFintersection(self, rand, CDF):
+    def _FindPDFintersection(self, rand, CDF):
 	'''Returns the global bin corresponding to the CDF intersection'''
 	found = False
 	for i in range(1, CDF.GetNbinsX()+1):
 	    PDFval = CDF.GetBinContent(i)
 	    if (PDFval > rand):
+		found = True
 		return i
 	if not found:
 	    raise ValueError('Intersection with CDF not found, something is wrong. Make sure that the random number is bounded by the maximum value found in the CDF')
 
-    def GlobalBinTo2D(self, globalBin):
+    def _GlobalBinTo2D(self, PDF, globalBin):
 	'''Converts the global bin (from the CDF intersection) to the 2D PDF bin
 	globalBins start from 1
 	globalBin 1 = (1,1), 2 = (1,2), and so on
 	'''
 	globalBin = globalBin - 1
-	NX = PDF.GetBinsX()
-	NY = PDF.GetBinsY()
+	NX = PDF.GetNbinsX()
+	NY = PDF.GetNbinsY()
 	localX = int(globalBin)/int(NY) + 1
 	localY = globalBin % NY + 1
 	return localX, localY
 
     def GeneratePseudoData(self, PDF, nEvents, CDF, name):
-	'''
-
-	'''
-
+	'''Generates toy data from the CDF of a given region'''
+	toy = PDF.Clone(name)
+	toy.Reset()
+	toy.SetDirectory(0)
+	print('Generating {} events for toy data hist {}'.format(int(nEvents), name))
+	for i in range(int(nEvents)):
+	    rand = random.uniform(0,CDF.GetMaximum()) # constrain the random number to be within the max of the CDF
+	    globalBin = self._FindPDFintersection(rand, CDF)
+	    nx, ny = self._GlobalBinTo2D(PDF, globalBin)
+	    nx = int(nx)
+	    ny = int(ny)
+	    toy.SetBinContent(nx, ny, toy.GetBinContent(nx,ny)+1)
+	return toy
 
     def Multiply(self, h1, h2, name=''):
-    '''Modified version of TH2::Multiply() which additionally zeroes negative bins'''
-	print('Multiplying {} x {}'.format(h1.GetName(),h2.GetName()))
+	'''Modified version of TH2::Multiply() which additionally zeroes negative bins'''
+	#print('Multiplying {} x {}'.format(h1.GetName(),h2.GetName()))
 	nh1 = (h1.GetNbinsX(),h1.GetNbinsY())
 	nh2 = (h2.GetNbinsX(),h2.GetNbinsY())
 	assert(nh1==nh2)
-	print('{} binning : {}\n{} binning : {}'.format(h1,nh1,h2,nh2))
+	#print('{} binning : {}\n{} binning : {}'.format(h1,nh1,h2,nh2))
 	finalHist = h1.Clone(name)
 	# loop over bins in h1
 	for i in range(0, h1.GetNbinsX()+1):

--- a/TwoDAlphabet/utils/make_pseudo.py
+++ b/TwoDAlphabet/utils/make_pseudo.py
@@ -141,6 +141,7 @@ class PseudoData:
 	    for i in range(len(bkg_sources)):
                 bkg_file = ROOT.TFile.Open(bkg_sources.iloc[i].source_filename)
                 bkg_hist = bkg_file.Get(bkg_sources.iloc[i].source_histname)
+		bkg_hist.SetDirectory(0)
 		template.Add(bkg_hist)
 		bkg_file.Close()
 		out[region] = bkg_hist


### PR DESCRIPTION
Allows for floating point bin edges, not only integers. This is useful for cases in which one of the observables is, for example, a discriminant. Should not effect analyses using integer bin widths, as `round()` function does not alter integers. 

Branch also includes implementation of SemiParametric class, in which only bins with a value above a user-defined ceiling will be freely floating in the fit, otherwise they will be of the given functional form. Useful when desiring functional form only in the tails of a distribution. 

Also includes fixes to the systematic plotting, when not every process has the same systematics. 